### PR TITLE
Configure the Sahabee to send timesheet to user

### DIFF
--- a/backend/rollcall/tasks.py
+++ b/backend/rollcall/tasks.py
@@ -42,15 +42,10 @@ def _is_today_1st_11th_or_21st_day_of_jalali_month() -> bool:
 
 def _send_user_timesheet(user):
     j_now = JalaliDateTime.now()
-    receiver_email = settings.TIMESHEETS_RECEIVER_EMAIL
-    if not receiver_email:
-        raise ValueError("No receiver email address.")
     if not user.detail.work_email:
         logging.info(f"User ({user.username}) work email not found. Emailing the corresponding timesheet ignored.")
         return
-    cc_list = [user.detail.work_email]
-    if user.detail.manager_email:
-        cc_list.append(user.detail.manager_email)
+    receiver_email = user.detail.work_email
 
     if j_now.day == 1:
         # The timesheet of the previous month should be sent in the first day of each month.
@@ -58,8 +53,8 @@ def _send_user_timesheet(user):
     else:
         report_jdatetime = j_now
     timesheet_file = ExcelConverter.generate_excel_file(user, report_jdatetime.year, report_jdatetime.month).getvalue()
-    body_text = f'''Hello, Here is the timesheet of a user at SahaBee. This email is sent automatically by SahaBee, 
-since the user was actively rollcalling at SahaBee during the last few days. 
+    body_text = f'''Hello, Here is the timesheet of you at SahaBee. As soon as possible, forward this email to the Edari
+    This email is sent automatically by SahaBee, since the user was actively rollcalling at SahaBee during the last few days.
 
 User Information:
 First name: {user.first_name}
@@ -76,9 +71,8 @@ https://sahabee.ir
 '''
     message = EmailMessage('SahaBee User Timesheet',
                            body_text,
-                           from_email=user.detail.work_email,
-                           to=[receiver_email],
-                           cc=cc_list,
+                           from_email='sahabee@mymail.sahab.ir',
+                           to=receiver_email,
                            attachments=[(f'timesheet-{user.detail.personnel_code}.xlsx',
                                          timesheet_file,
                                          'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')])

--- a/backend/rollcall/tasks.py
+++ b/backend/rollcall/tasks.py
@@ -53,8 +53,8 @@ def _send_user_timesheet(user):
     else:
         report_jdatetime = j_now
     timesheet_file = ExcelConverter.generate_excel_file(user, report_jdatetime.year, report_jdatetime.month).getvalue()
-    body_text = f'''Hello, Here is the timesheet of you at SahaBee. As soon as possible, forward this email to the Edari
-    This email is sent automatically by SahaBee, since the user was actively rollcalling at SahaBee during the last few days.
+    body_text = f'''Hello, Here is the timesheet of you at SahaBee. As soon as possible, forward this email to the Office
+    This email is sent automatically, since you have actively roll-calling at SahaBee during the last few days.
 
 User Information:
 First name: {user.first_name}
@@ -71,8 +71,7 @@ https://sahabee.ir
 '''
     message = EmailMessage('SahaBee User Timesheet',
                            body_text,
-                           from_email='sahabee@mymail.sahab.ir',
-                           to=receiver_email,
+                           to=[receiver_email],
                            attachments=[(f'timesheet-{user.detail.personnel_code}.xlsx',
                                          timesheet_file,
                                          'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')])

--- a/backend/rollcall/tests/test_timesheet_send.py
+++ b/backend/rollcall/tests/test_timesheet_send.py
@@ -41,10 +41,6 @@ class TimeSheetPeriodicSendTest(TestCase):
         tasks.send_active_timesheets_if_today_is_appropriate_day_of_month()
         self.assertEqual(len(mail.outbox), 0)
 
-    def test_email_is_sent_from_users_work_email_address(self):
-        tasks.send_active_timesheets_if_today_is_appropriate_day_of_month()
-        self.assertEqual(mail.outbox[0].from_email, self.user.detail.work_email)
-
     def test_email_should_not_send_when_user_has_no_work_email(self):
         self.user.detail.work_email = ''
         self.user.detail.save()


### PR DESCRIPTION
 # Since changes of email server, Sahabee cannot send email instead of user to
   the Edari department directly, So the Sahabee try to send the timesheet to
   user and the user forward it to the Edari department